### PR TITLE
Update to Twilio 6.16.2

### DIFF
--- a/rtwilio/outgoing.py
+++ b/rtwilio/outgoing.py
@@ -1,7 +1,7 @@
 import pprint
 import logging
 
-from twilio.rest import TwilioRestClient
+from twilio.rest import Client
 
 from rapidsms.backends.base import BackendBase
 from rapidsms.errors import MessageSendingError
@@ -15,8 +15,8 @@ class TwilioBackend(BackendBase):
 
     def configure(self, config=None, **kwargs):
         self.config = config
-        self.client = TwilioRestClient(self.config['account_sid'],
-                                       self.config['auth_token'])
+        self.client = Client(self.config['account_sid'],
+                             self.config['auth_token'])
 
     def prepare_message(self, id_, text, identities, context):
         encoding = self.config.get('encoding', 'ascii')
@@ -37,7 +37,7 @@ class TwilioBackend(BackendBase):
             data['to'] = identity
             logger.debug('POST data: %s' % pprint.pformat(data))
             try:
-                self.client.sms.messages.create(**data)
+                self.client.messages.create(**data)
             except Exception:
                 failed_identities.append(identity)
                 logger.exception("Failed to create Twilio message.")

--- a/rtwilio/views.py
+++ b/rtwilio/views.py
@@ -8,7 +8,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
 
 from rapidsms.backends.http.views import GenericHttpBackendView
-from twilio.util import RequestValidator
+from twilio.request_validator import RequestValidator
 
 from rtwilio.models import TwilioResponse
 from rtwilio.forms import StatusCallbackForm, TwilioForm

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=(
         'rapidsms>=0.18',
         'django>=1.7',
-        'twilio>=3.5,<4.0',
+        'twilio>=3.5,<=6.16.2',
     ),
     test_suite="runtests.runtests",
 )


### PR DESCRIPTION
This PR updates `rapidsms-twilio` to enable the latest version of Twilio, which splits and rejoins messages longer than 160 characters. 

Handles https://github.com/datamade/rapidsms-decisiontree-app/issues/7