### PR TITLE
Pin to later version of Twilio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=(
         'rapidsms>=0.18',
         'django>=1.7',
-        'twilio>=3.5,<=6.16.2',
+        'twilio>=6.0.0,<=6.16.2',
     ),
     test_suite="runtests.runtests",
 )


### PR DESCRIPTION
The changes in PR #1 require `rapidsms-twilio` to use version 6+ of Twilio ([which introduces the `request_validator`](https://www.twilio.com/docs/libraries/reference/twilio-python/6.0.0/request_validator.m.html)).